### PR TITLE
Scheduler for updating the game state

### DIFF
--- a/resources/default.edn
+++ b/resources/default.edn
@@ -1,2 +1,3 @@
 {:server-port #ts/env [:port "8080"]
- :metrics     {:prometheus {:metrics-path "/metrics"}}}
+ :metrics     {:prometheus {:metrics-path "/metrics"}}
+ :scheduler   {:cpu-count 2}}

--- a/src/clj/com/github/discoverAI/snake/core.clj
+++ b/src/clj/com/github/discoverAI/snake/core.clj
@@ -11,7 +11,7 @@
 (defn snake-system [runtime-config]
   (-> (system/base-system runtime-config)
       (assoc
-        :engine (c/using (eg/new-engine) [:app-status])
+        :engine (c/using (eg/new-engine) [:app-status :scheduler])
         :endpoint (c/using (ep/new-endpoint) [:handler :engine]))
       (httpkit/add-server :endpoint)))
 

--- a/src/clj/com/github/discoverAI/snake/endpoint.clj
+++ b/src/clj/com/github/discoverAI/snake/endpoint.clj
@@ -23,8 +23,8 @@
   (def ring-ajax-get-or-ws-handshake ajax-get-or-ws-handshake-fn)
   (def ch-chsk ch-recv)                                     ; ChannelSocket's receive channel
   (def chsk-send! send-fn)                                  ; ChannelSocket's send API fn
-  (def connected-uids connected-uids)                       ; Watchable, read-only atom
-  )
+  (def connected-uids connected-uids))                       ; Watchable, read-only atom
+
 
 (defn endpoint-filter [handler]
   (cc/routes

--- a/src/clj/com/github/discoverAI/snake/engine.clj
+++ b/src/clj/com/github/discoverAI/snake/engine.clj
@@ -35,25 +35,21 @@
                         [new-head]
                         (vec (butlast snake)))))))
 
-
-
-
 (defn atomically-update-game-state
-  [games]
-  (doseq [[game-id _game] @games]
-    (swap! games update game-id move)))
+  [games game-id]
+  (swap! games update game-id move))
 
 (defn register-move-dispatch
-  [games scheduler]
-  (overtone.at-at/every 1000
-                        #(atomically-update-game-state games)
+  [games game-id scheduler]
+  (overtone.at-at/every move-speed
+                        #(atomically-update-game-state games game-id)
                         (de.otto.tesla.stateful.scheduler/pool scheduler)
                         :desc "UpdateGameStateTask"))
 
 (defn register-new-game [{:keys [games scheduler]} width height snake-length]
   (let [game (new-game width height snake-length)
         id (first (keys game))]
-    (register-move-dispatch games scheduler)
+    (register-move-dispatch games id scheduler)
     (swap! games merge game)
     id))
 

--- a/src/clj/com/github/discoverAI/snake/engine.clj
+++ b/src/clj/com/github/discoverAI/snake/engine.clj
@@ -11,6 +11,20 @@
        (str "G_")
        (keyword)))
 
+(defn on-tick [game-state]
+  (let [pos-path [:tokens :snake :position]
+        position (get-in game-state pos-path)
+        dir (get-in game-state [:tokens :snake :direction])
+        new-head (vec (map + dir (first position)))]
+    (cond
+      ;TODO check if we run out of bounds or snake eats itself (seperate task)
+      :else (assoc-in game-state pos-path
+              (into
+                [new-head] ;the next snake head will be appended at beginning of the list
+                (vec (butlast position)))) ;the tail will be cut off
+    )
+  ))
+
 (defn new-game [width height snake-length]
   (let [game-state (b/initial-state width height snake-length)]
     {(game-id game-state) game-state}))

--- a/src/clj/com/github/discoverAI/snake/engine.clj
+++ b/src/clj/com/github/discoverAI/snake/engine.clj
@@ -22,17 +22,14 @@
 
 (def MOVE_UPDATE_INTERVAL 1000)
 
+(defn move-snake [{:keys [direction] :as snake}]
+  (update snake :position
+          (fn [snake-position]
+            (concat [(vector-addition (first snake-position) direction)]
+                    (drop-last snake-position)))))
+
 (defn move [game-state]
-  (let [snake-path [:tokens :snake :position]
-        snake (get-in game-state snake-path)
-        direction (get-in game-state [:tokens :snake :direction])
-        new-head (vector-addition direction (first snake))]
-    (cond
-      ;TODO check if we run out of bounds or snake eats itself (seperate task)
-      :else (assoc-in game-state snake-path
-                      (into
-                        [new-head]
-                        (vec (butlast snake)))))))
+  (update-in game-state [:tokens :snake] move-snake))
 
 (defn register-new-game [{:keys [games scheduler]} width height snake-length]
   (let [game (new-game width height snake-length)

--- a/src/clj/com/github/discoverAI/snake/engine.clj
+++ b/src/clj/com/github/discoverAI/snake/engine.clj
@@ -17,8 +17,7 @@
   (let [game-state (b/initial-state width height snake-length)]
     {(game-id game-state) game-state}))
 
-(defn vector-addition
-  [first second]
+(defn vector-addition [first second]
   (vec (map + first second)))
 
 (def MOVE_UPDATE_INTERVAL 1000)

--- a/src/clj/com/github/discoverAI/snake/engine.clj
+++ b/src/clj/com/github/discoverAI/snake/engine.clj
@@ -11,19 +11,21 @@
        (str "G_")
        (keyword)))
 
+(defn vector-addition
+  [first second]
+  (vec (map + first second)))
+
 (defn on-tick [game-state]
-  (let [pos-path [:tokens :snake :position]
-        position (get-in game-state pos-path)
-        dir (get-in game-state [:tokens :snake :direction])
-        new-head (vec (map + dir (first position)))]
+  (let [snake-path [:tokens :snake :position]
+        snake (get-in game-state snake-path)
+        direction (get-in game-state [:tokens :snake :direction])
+        new-head (vector-addition direction (first snake))]
     (cond
       ;TODO check if we run out of bounds or snake eats itself (seperate task)
-      :else (assoc-in game-state pos-path
-              (into
-                [new-head] ;the next snake head will be appended at beginning of the list
-                (vec (butlast position)))) ;the tail will be cut off
-    )
-  ))
+      :else (assoc-in game-state snake-path
+                      (into
+                        [new-head]
+                        (vec (butlast snake)))))))
 
 (defn new-game [width height snake-length]
   (let [game-state (b/initial-state width height snake-length)]

--- a/test/clj/com/github/discoverAI/snake/engine_test.clj
+++ b/test/clj/com/github/discoverAI/snake/engine_test.clj
@@ -53,3 +53,11 @@
 
                        (is (= game-20-20-3
                               (game-20-20-3-id @(get-in system [:engine :games]))))))))
+
+(deftest on-tick-should-move-the-snake
+  (testing "On a tick, the snake should move one pixel into the given direction"
+    (is (= {:board  [20 20]
+            :tokens {:snake {:position  [[12 10] [11 10] [10 10]]
+                             :direction [1 0]
+                             :speed     1.0}}} (eg/on-tick game-20-20-3))))
+   )

--- a/test/clj/com/github/discoverAI/snake/engine_test.clj
+++ b/test/clj/com/github/discoverAI/snake/engine_test.clj
@@ -10,8 +10,8 @@
    :tokens {:snake {:position  [[11 10] [10 10] [9 10]]
                     :direction [1 0]
                     :speed     1.0}}})
-(def game-20-20-3-id
-  :foobar)
+
+(def game-20-20-3-id :foobar)
 
 (deftest game-id-test
   (testing "Should calculate a unique game id"
@@ -56,22 +56,17 @@
 
 (deftest test-vector-add
   (testing "On a tick, the snake should move one pixel into the given direction"
-    (is (= [1 4] (eg/vector-addition [1 2] [0 2])))
-    )
-  )
+    (is (= [1 4] (eg/vector-addition [1 2] [0 2])))))
 
 (deftest on-tick-should-move-the-snake
   (testing "On a tick, the snake should move one pixel into the given direction"
     (is (= {:board  [20 20]
             :tokens {:snake {:position  [[12 10] [11 10] [10 10]]
                              :direction [1 0]
-                             :speed     1.0}}} (eg/on-tick game-20-20-3))))
-   )
+                             :speed     1.0}}} (eg/move game-20-20-3)))))
 
 (deftest atomically-update-game-state
   (testing "If the game state is updated"
     (let [atom (atom {game-20-20-3-id game-20-20-3})]
       (eg/atomically-update-game-state atom)
-      (is (= @atom {game-20-20-3-id (eg/on-tick  game-20-20-3)})
-      )
-    )))
+      (is (= @atom {game-20-20-3-id (eg/move game-20-20-3)})))))

--- a/test/clj/com/github/discoverAI/snake/engine_test.clj
+++ b/test/clj/com/github/discoverAI/snake/engine_test.clj
@@ -46,7 +46,7 @@
                                (is (= game-20-20-3
                                       game-state))
                                game-20-20-3-id)
-                  eg/register-move-dispatch (fn [_ _])]
+                  eg/register-move-dispatch (fn [_ _ _])]
       (tu/with-started [system (co/snake-system {})]
                        (is (not= nil
                                  (:engine system)))
@@ -71,16 +71,16 @@
 (deftest atomically-update-game-state
   (testing "If the game state is updated"
     (let [atom (atom {game-20-20-3-id game-20-20-3})]
-      (eg/atomically-update-game-state atom)
+      (eg/atomically-update-game-state atom game-20-20-3-id)
       (is (= @atom {game-20-20-3-id (eg/move game-20-20-3)})))))
 
 (deftest test-scheduling
   (testing "if the move is scheduled"
     (with-redefs
       [eg/atomically-update-game-state
-       (fn [c] (swap! c inc))]
+       (fn [a _] (swap! a inc))]
       (tu/with-started [system (co/snake-system {})]
                        (let [a (atom 0)]
-                         (eg/register-move-dispatch a (:scheduler system))
+                         (eg/register-move-dispatch a :mock-id (:scheduler system))
                          (Thread/sleep (+ eg/move-speed 50))
                          (is (= @a 2)))))))

--- a/test/clj/com/github/discoverAI/snake/engine_test.clj
+++ b/test/clj/com/github/discoverAI/snake/engine_test.clj
@@ -3,9 +3,7 @@
             [de.otto.tesla.util.test-utils :as tu]
             [com.github.discoverAI.snake.core :as co]
             [com.github.discoverAI.snake.engine :as eg]
-            [clojure.string :as s]
-            [de.otto.tesla.stateful.scheduler :as sch]
-            [overtone.at-at :as ot]))
+            [clojure.string :as s]))
 
 (def game-20-20-3
   {:board  [20 20]

--- a/test/clj/com/github/discoverAI/snake/engine_test.clj
+++ b/test/clj/com/github/discoverAI/snake/engine_test.clj
@@ -54,6 +54,12 @@
                        (is (= game-20-20-3
                               (game-20-20-3-id @(get-in system [:engine :games]))))))))
 
+(deftest test-vector-add
+  (testing "On a tick, the snake should move one pixel into the given direction"
+    (is (= [1 4] (eg/vector-addition [1 2] [0 2])))
+    )
+  )
+
 (deftest on-tick-should-move-the-snake
   (testing "On a tick, the snake should move one pixel into the given direction"
     (is (= {:board  [20 20]

--- a/test/clj/com/github/discoverAI/snake/engine_test.clj
+++ b/test/clj/com/github/discoverAI/snake/engine_test.clj
@@ -67,3 +67,11 @@
                              :direction [1 0]
                              :speed     1.0}}} (eg/on-tick game-20-20-3))))
    )
+
+(deftest atomically-update-game-state
+  (testing "If the game state is updated"
+    (let [atom (atom {game-20-20-3-id game-20-20-3})]
+      (eg/atomically-update-game-state atom)
+      (is (= @atom {game-20-20-3-id (eg/on-tick  game-20-20-3)})
+      )
+    )))

--- a/test/clj/com/github/discoverAI/snake/engine_test.clj
+++ b/test/clj/com/github/discoverAI/snake/engine_test.clj
@@ -70,9 +70,9 @@
 
 (deftest atomically-update-game-state
   (testing "If the game state is updated"
-    (let [atom (atom {game-20-20-3-id game-20-20-3})]
+    (let [atom (atom {game-20-20-3-id game-20-20-3 :foobazz game-20-20-3})]
       (eg/atomically-update-game-state atom game-20-20-3-id)
-      (is (= @atom {game-20-20-3-id (eg/move game-20-20-3)})))))
+      (is (= @atom {game-20-20-3-id (eg/move game-20-20-3) :foobazz game-20-20-3})))))
 
 (deftest test-scheduling
   (testing "if the move is scheduled"

--- a/test/clj/com/github/discoverAI/snake/engine_test.clj
+++ b/test/clj/com/github/discoverAI/snake/engine_test.clj
@@ -39,46 +39,36 @@
                 (eg/new-game 21 19 7))))))
 
 (deftest register-new-game-test
-  (testing "Should add a new game to component"
-    (with-redefs [eg/game-id (fn [game-state]
-                               (is (= game-20-20-3
-                                      game-state))
-                               game-20-20-3-id)
-                  eg/register-move-dispatch (fn [_ _ _])]
-      (tu/with-started [system (co/snake-system {})]
-                       (is (not= nil
-                                 (:engine system)))
+  (testing "Should add a new game to component and register move function with scheduler"
+    (let [moved? (atom false)]
+      (with-redefs [eg/game-id (fn [game-state]
+                                 (is (= game-20-20-3 game-state))
+                                 game-20-20-3-id)
+                    eg/move (fn [game-state]
+                              (is (= game-20-20-3 game-state))
+                              (reset! moved? true)
+                              game-state)]
+        (tu/with-started [system (co/snake-system {})]
+                         (is (not= nil
+                                   (:engine system)))
 
-                       (is (= game-20-20-3-id
-                              (eg/register-new-game (:engine system) 20 20 3)))
+                         (is (= game-20-20-3-id
+                                (eg/register-new-game (:engine system) 20 20 3)))
 
-                       (is (= game-20-20-3
-                              (game-20-20-3-id @(get-in system [:engine :games]))))))))
+                         (is (= game-20-20-3
+                                (game-20-20-3-id @(get-in system [:engine :games]))))
+
+                         (tu/eventually (is (= true @moved?))))))))
 
 (deftest test-vector-add
   (testing "On a tick, the snake should move one pixel into the given direction"
-    (is (= [1 4] (eg/vector-addition [1 2] [0 2])))))
+    (is (= [1 4]
+           (eg/vector-addition [1 2] [0 2])))))
 
-(deftest on-tick-should-move-the-snake
-  (testing "On a tick, the snake should move one pixel into the given direction"
+(deftest move-the-snake
+  (testing "move snake one pixel into the given direction"
     (is (= {:board  [20 20]
             :tokens {:snake {:position  [[12 10] [11 10] [10 10]]
                              :direction [1 0]
-                             :speed     1.0}}} (eg/move game-20-20-3)))))
-
-(deftest atomically-update-game-state
-  (testing "If the game state is updated"
-    (let [atom (atom {game-20-20-3-id game-20-20-3 :foobazz game-20-20-3})]
-      (eg/atomically-update-game-state atom game-20-20-3-id)
-      (is (= @atom {game-20-20-3-id (eg/move game-20-20-3) :foobazz game-20-20-3})))))
-
-(deftest test-scheduling
-  (testing "if the move is scheduled"
-    (with-redefs
-      [eg/atomically-update-game-state
-       (fn [a _] (swap! a inc))]
-      (tu/with-started [system (co/snake-system {})]
-                       (let [a (atom 0)]
-                         (eg/register-move-dispatch a :mock-id (:scheduler system))
-                         (Thread/sleep (+ eg/move-speed 50))
-                         (is (= @a 2)))))))
+                             :speed     1.0}}}
+           (eg/move game-20-20-3)))))


### PR DESCRIPTION
the scheduler right now just updates *every* game every second. 
it would make more sense to schedule a task for each game with the speed parameter in the data structure right?

but how do i then pass the scheduler dependency in the register-game-function? it is only available in the engine 
